### PR TITLE
Bugfix/change updates

### DIFF
--- a/lib/generators/message_quickly/callbacks/USAGE
+++ b/lib/generators/message_quickly/callbacks/USAGE
@@ -5,7 +5,11 @@ Example:
     rails generate callbacks
 
     This will create:
+        config/initializers/webhooks.rb
         app/webhooks/authentication_callback.rb
         app/webhooks/message_delivered_callback.rb
         app/webhooks/message_received_callback.rb
         app/webhooks/postback_callback.rb
+        app/webhooks/change_update_callback.rb
+        app/jobs/process_messenger_callback_job.rb
+        app/jobs/send_messenger_delivery_job.rb

--- a/lib/generators/message_quickly/callbacks/callbacks_generator.rb
+++ b/lib/generators/message_quickly/callbacks/callbacks_generator.rb
@@ -13,6 +13,8 @@ module MessageQuickly
         copy_file "message_received_callback.rb", "app/webhooks/message_received_callback.rb"
         copy_file "postback_callback.rb", "app/webhooks/postback_callback.rb"
 
+        copy_file "change_update_callback.rb", "app/webhooks/change_update_callback.rb"
+
         copy_file "process_messenger_callback_job.rb", "app/jobs/process_messenger_callback_job.rb"
         copy_file "send_messenger_delivery_job.rb", "app/jobs/send_messenger_delivery_job.rb"
 

--- a/lib/generators/message_quickly/callbacks/templates/change_update_callback.rb
+++ b/lib/generators/message_quickly/callbacks/templates/change_update_callback.rb
@@ -1,0 +1,14 @@
+class ChangeUpdateCallback < MessageQuickly::Callback
+
+  def self.webhook_name
+    :changes
+  end
+
+  def initialize(event, json)
+    super
+  end
+
+  def run
+  end
+
+end

--- a/lib/message_quickly/change_update_event.rb
+++ b/lib/message_quickly/change_update_event.rb
@@ -1,0 +1,36 @@
+module MessageQuickly
+  class ChangeUpdateEvent
+
+    attr_reader :changes
+
+    def initialize(params = {})
+      @object_id = params[:entry].id
+      @time = params[:entry].time
+      @changes = params[:changes]
+    end
+
+    def webhook_name
+      :changes
+    end
+
+  end
+end
+
+# {
+#   "object":"page",
+#   "entry":[
+#       {
+#         "id":"PAGE_ID",
+#         "time":1476077449,
+#         "changes":[
+#             {
+#               "field":"conversations",
+#               "value":{
+#                 "thread_id":"CONVERSATION_ID",
+#                 "page_id":"PAGE_ID"
+#               }
+#             }
+#           ]
+#       }
+#     ]
+# }

--- a/spec/callback_parser_spec.rb
+++ b/spec/callback_parser_spec.rb
@@ -82,6 +82,17 @@ module MessageQuickly
 
     end
 
+    context 'with a change notification event' do
+
+      let(:message_json) { JSON.parse(File.read("spec/fixtures/change_notification_request.json")) }
+
+      subject { CallbackParser.new(message_json) }
+
+      it { expect { |b| subject.parse(&b) }.to yield_with_args(ChangeUpdateEvent) }
+      it { expect(subject.parse).not_to be_empty }
+
+    end
+
   end
 
 end

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -124,6 +124,23 @@ describe MessageQuickly::WebhooksController, type: :controller do
 
     end
 
+    context 'with a change update event' do
+
+      let(:optin_json) { File.read("spec/fixtures/change_notification_request.json") }
+
+      context 'with valid params' do
+        before { post :callback, optin_json }
+        it { expect(response).to have_http_status(200) }
+      end
+
+      context 'with invalid params' do
+        before { post :callback, 'invalid json' }
+        it { expect(response.body).to eq('Error processing callback') }
+        it { expect(response).to have_http_status(500) }
+      end
+
+    end
+
   end
 
 end

--- a/spec/dummy/app/webhooks/change_update_callback.rb
+++ b/spec/dummy/app/webhooks/change_update_callback.rb
@@ -1,0 +1,14 @@
+class ChangeUpdateCallback
+
+  def self.webhook_name
+    :changes
+  end
+
+  def initialize(event, json)
+    super
+  end
+
+  def run
+  end
+
+end

--- a/spec/fixtures/change_notification_request.json
+++ b/spec/fixtures/change_notification_request.json
@@ -1,0 +1,18 @@
+{
+  "object":"page",
+  "entry":[
+      {
+        "id":"PAGE_ID",
+        "time":1476077449,
+        "changes":[
+            {
+              "field":"conversations",
+              "value":{
+                "thread_id":"CONVERSATION_ID",
+                "page_id":"PAGE_ID"
+              }
+            }
+          ]
+      }
+    ]
+}

--- a/spec/message_quickly/api/messages_spec.rb
+++ b/spec/message_quickly/api/messages_spec.rb
@@ -91,7 +91,7 @@ describe MessageQuickly::Api::Messages do
 
       it 'should be able to send with an video url attachment' do
         delivery = subject.create(recipient) do |message|
-          message.build_attachment(:video) { |attachment| attachment.url = 'http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_1mb.mp4' }
+          message.build_attachment(:video) { |attachment| attachment.url = 'http://techslides.com/demos/sample-videos/small.mp4' }
         end
         expect(delivery.id).not_to be_nil
       end


### PR DESCRIPTION
Fix #5 Not handling updates from Facebook Webhooks.

This PR resolves the above issue by implementing the `ChangeUpdateEvent` and integrating it with the `MessageQuickly::CallbackParser` to handle the change updates.

Note: I couldn't figure out how the `spec/dummy` plays into the specs, so I'm not sure the integration is fully tested, although I did add the new event handling into the specs for `MessageQuickly::CallbackParser`